### PR TITLE
Refactor coin name truncation & Fix coin name in CoinDetails

### DIFF
--- a/src/components/atoms/CoinId/CoinId.js
+++ b/src/components/atoms/CoinId/CoinId.js
@@ -5,6 +5,7 @@ import CoinNameAndCode from '../CoinNameAndCode/CoinNameAndCode';
 
 const CoinId = ({
   data: { name, code, webp64 },
+  maxNameLength,
   isCoinDetails,
   isSearchResult,
   isLink,
@@ -25,6 +26,7 @@ const CoinId = ({
             code={code}
             isCoinDetails={isCoinDetails}
             isSearchResult={isSearchResult}
+            maxNameLength={maxNameLength}
           />
         </StyledLink>
       ) : (
@@ -33,6 +35,7 @@ const CoinId = ({
           code={code}
           isCoinDetails={isCoinDetails}
           isSearchResult={isSearchResult}
+          maxNameLength={maxNameLength}
         />
       )}
     </Wrapper>
@@ -41,6 +44,7 @@ const CoinId = ({
 
 CoinId.propTypes = {
   name: PropTypes.string,
+  nameLength: PropTypes.number,
   code: PropTypes.string,
   webp64: PropTypes.string,
   isCoinDetails: PropTypes.bool,

--- a/src/components/atoms/CoinNameAndCode/CoinNameAndCode.js
+++ b/src/components/atoms/CoinNameAndCode/CoinNameAndCode.js
@@ -2,7 +2,13 @@ import React from 'react';
 import { Wrapper, Name, Code } from './CoinNameAndCode.styles';
 import { truncateString, trimUnderscoresAndSpaces } from 'helpers/general';
 
-const CoinNameAndCode = ({ name, code, isCoinDetails, isSearchResult }) => {
+const CoinNameAndCode = ({
+  name,
+  code,
+  isCoinDetails,
+  isSearchResult,
+  maxNameLength,
+}) => {
   return (
     <Wrapper>
       {!isCoinDetails ? (
@@ -11,7 +17,9 @@ const CoinNameAndCode = ({ name, code, isCoinDetails, isSearchResult }) => {
         </Code>
       ) : null}
       <Name isCoinDetails={isCoinDetails} isSearchResult={isSearchResult}>
-        {isSearchResult ? truncateString(name, 25) : truncateString(name, 13)}
+        {isSearchResult
+          ? truncateString(name, maxNameLength)
+          : truncateString(name, maxNameLength)}
       </Name>
       {isCoinDetails ? (
         <Code isCoinDetails={isCoinDetails}>

--- a/src/components/atoms/SearchResultsItem/SearchResultsItem.js
+++ b/src/components/atoms/SearchResultsItem/SearchResultsItem.js
@@ -6,7 +6,7 @@ const SearchResultsItem = React.forwardRef(
   ({ data, isHighlighted, ...props }, ref) => {
     return (
       <StyledLi ref={ref} isHighlighted={isHighlighted} {...props}>
-        <CoinId data={data} isSearchResult />
+        <CoinId data={data} isSearchResult maxNameLength={24} />
       </StyledLi>
     );
   }

--- a/src/components/molecules/CoinsTableRow/CoinsTableRow.js
+++ b/src/components/molecules/CoinsTableRow/CoinsTableRow.js
@@ -31,7 +31,7 @@ const CoinsTableRow = ({
         </RankAndWatch>
       </TdTh>
       <TdTh>
-        <CoinId isLink data={data} />
+        <CoinId isLink data={data} maxNameLength={13} />
       </TdTh>
       <TdTh isRight>${RoundSmallValue(rate)}</TdTh>
       <TdTh isRight>${roundLargeValue(cap)}</TdTh>

--- a/src/components/molecules/PortfolioTableRow/PortfolioTableRow.js
+++ b/src/components/molecules/PortfolioTableRow/PortfolioTableRow.js
@@ -30,7 +30,7 @@ const PortfolioTableRow = ({
     <>
       <StyledRow>
         <TdTh isLeft>
-          <CoinId isLink data={data} />
+          <CoinId isLink data={data} maxNameLength={15} />
         </TdTh>
         <TdTh isRight>${RoundSmallValue(rate)}</TdTh>
         <TdTh isRight>{RoundSmallValue(quantity)}</TdTh>

--- a/src/helpers/general.js
+++ b/src/helpers/general.js
@@ -20,10 +20,11 @@ export function roundLargeValue(cap) {
   return round(cap);
 }
 
-export function truncateString(string, desiredLength) {
-  if (string.length <= desiredLength) return string;
+export function truncateString(string, maxLength) {
+  if (!maxLength) return string;
+  if (string.length <= maxLength) return string;
 
-  return string.slice(0, desiredLength - 3) + '...';
+  return string.slice(0, maxLength - 3) + '...';
 }
 
 export function compareObjBy(a, b, key, isAscending) {


### PR DESCRIPTION
Now to truncate coin name for CoinId, maxNameLength has to be provided, by default name is not truncated.

That allows for easily making coin name on CoinDetails not truncated.